### PR TITLE
feat(TNG-1182): UKRDC Stats - Excessive Warnings?

### DIFF
--- a/ukrdc_stats/calculators/krt.py
+++ b/ukrdc_stats/calculators/krt.py
@@ -419,7 +419,7 @@ class KRTStatsCalculator(AbstractFacilityStatsCalculator):
 
         raw_patients = raw_patients.groupby("ukrdcid", as_index=False)[
             raw_patients.columns
-        ].apply(adjust_next_fromtime, include_group=False)
+        ].apply(adjust_next_fromtime, include_groups=False)
 
         return raw_patients
 
@@ -516,7 +516,8 @@ class KRTStatsCalculator(AbstractFacilityStatsCalculator):
             .apply(
                 lambda x: x["totime"].idxmax()
                 if x["totime"].notna().any()
-                else x["fromtime"].idxmax()
+                else x["fromtime"].idxmax(),
+                include_groups=False
             )
             .values,
             "most_recent",


### PR DESCRIPTION
added include_groups args, as far as i can tell in pandas 3.0 this is not needed, but rather than updating to pandas 3.0 i added the missing args